### PR TITLE
Display prefix from config in presence

### DIFF
--- a/bot/main.js
+++ b/bot/main.js
@@ -41,10 +41,10 @@ client.once('ready', async () => {
   console.log(`${client.guilds.size} servers`);
   // console.log(`${client.shard.count} shards`); // for future use once sharding becomes necessary
   if(client.guilds.size < 2) {
-    client.user.setActivity(`!!help`, { type: 'LISTENING'});
+    client.user.setActivity(`${config.prefix}help`, { type: 'LISTENING'});
   }
   else {
-    client.user.setActivity(`!!help | in ${client.guilds.size} servers`, { type: 'LISTENING'});
+    client.user.setActivity(`${config.prefix}help | in ${client.guilds.size} servers`, { type: 'LISTENING'});
   }
 });
 


### PR DESCRIPTION
Pulls the prefix from `config.json` and displays it in the presence status of the bot. Useful for bot owners who use a custom prefix by default and want it to show up for all guilds the bot is in. 