### PR TITLE
Add more help info to character commands

### DIFF
--- a/bot/commands/character.js
+++ b/bot/commands/character.js
@@ -13,7 +13,13 @@ module.exports = {
 Adds a new character with the name \`<name>\`
 **<character> remove**
 Removes the character \`<character>\`
-**<character> colour <hex|word>**
+**<character> proxy [example match]**
+Sets the proxy tags for \`<character>\` by the example match given.
+Proxy tags enable you to speak as your character by typing text between the set tags.
+Try out square brackets as proxy tags by using \`[text]\` as the example match.
+**<character> avatar [attachment | url]**
+Sets the avatar for \`<character>\` to the attached image or the image at the URL
+**<character> colour <hex | word>**
 Sets \`<character>\`'s colour to a hex code or a word
 **<character> description <description>**
 Sets \`<character>\`'s description to \`<description>\`
@@ -26,7 +32,7 @@ Renames \`<character>\``,
   hidden: false,
   args: false,
   argsMin: 0,
-  usage: [`[character]`,`add <name>`,`<character> remove`,`<character> colour <hex|word>`,`<character> description <description>`, `<character> reference add <name> <url>`,`<character> reference remove <name>`, `<character> rename <New name>`,`<character> avatar <url|attatchment>`],
+  usage: [`[character]`,`add <name>`,`<character> remove`,`<character> colour <hex | word>`,`<character> description <description>`, `<character> reference add <name> <url>`,`<character> reference remove <name>`, `<character> rename <New name>`,`<character> avatar <url | attatchment>`],
   example: '',
 	async execute(client, guildSettings, msg, args) {
     const charactersList = guildSettings.characters.sort((a,b)=>{
@@ -197,7 +203,12 @@ Renames \`<character>\``,
               console.log(err)
               return msg.channel.send(utils.errorEmbed("There was an error trying to execute that command"))
             }
-            return msg.channel.send(utils.passEmbed(`Updataed avatar!`))
+            if(character.avatar == undefined) {
+              return msg.channel.send(utils.passEmbed(`Cleared avatar!`))
+            }
+            else {
+            return msg.channel.send(utils.passEmbed(`Updated avatar!`))
+            }
           })
         break;
 
@@ -210,7 +221,7 @@ Renames \`<character>\``,
                 console.log(err)
                 return msg.channel.send(utils.errorEmbed("There was an error trying to execute that command"))
               }
-              return msg.channel.send(utils.passEmbed(`Updataed name to ${character.name}!`))
+              return msg.channel.send(utils.passEmbed(`Updated name to ${character.name}!`))
             })
         break;
 

--- a/bot/commands/character.js
+++ b/bot/commands/character.js
@@ -50,7 +50,7 @@ Renames \`<character>\``,
     })
     if(args.length == 0){
       if(charactersList.length == 0){
-        return msg.channel.send(utils.errorEmbed(`This server has no characters\nCreate one with \`${guildSettings.prefix}character add <name>\``))
+        return msg.channel.send(utils.errorEmbed(`This server has no characters\nCreate one with \`${guildSettings.prefix || `@${client.user.username}${client.user.tag} `}character add <name>\``))
       }
       response = utils.passEmbed()
       response.setTitle(`Characters for ${guildSettings.gameName || msg.guild.name}`)
@@ -140,7 +140,12 @@ Renames \`<character>\``,
               console.log(err)
               return msg.channel.send(utils.errorEmbed("There was an error trying to execute that command"))
             }
+            if(!character.description) {
+              return msg.channel.send(utils.passEmbed(`Cleared description!`))
+            }
+            else {
             return msg.channel.send(utils.passEmbed(`Set new description!`))
+            }
           })
         break;
 
@@ -213,6 +218,7 @@ Renames \`<character>\``,
         break;
 
         case "rename":
+        case "name":
           if(args.length < 3) return msg.channel.send(utils.errorEmbed("A character must have a name!"))
           var newName = args.slice(2).join(" ")
           character.name = newName

--- a/bot/commands/info.js
+++ b/bot/commands/info.js
@@ -1,4 +1,4 @@
-const utils = require('../util');
+const utils = require('../util.js');
 const config = require("../config.json")
 
 module.exports = {
@@ -32,14 +32,14 @@ module.exports = {
     const githubUrl = "https://github.com/PlatypodeCode/CinnamonRP";
     // Generate Embed
     const infoMessage = "CinnamonRP is a bot designed for roleplay on Discord. It allows you to create characters and set up message proxying, set scenes and define locations, post as NPCs, roll dice and more.\n\nType \`!!help\` for a list of commands and \`!!help [command]\` to find out how they work!\n\nWe also have a support server for help, announcements, discussion, suggestions, etc";
-    const serverUrl = "https://discord.gg/NjrSpBY";
+    const serverUrl = "https://discord.gg/PrKWQP2";
     const embed = utils.passEmbed()
       .addField("CinnamonRP", infoMessage)
       .addField("Add the bot!",`[Click here to add CinnamonRP to your server](${inviteUrl})`)
       .addField("See the code!",`[Click here to view the GitHub for CinnamonRP](${githubUrl})`)
       .addField("Get help!", `[Click here to join our support server](${serverUrl})`);
       if(config.owner.name != "") embed.setFooter(`Instance Owner: ${config.owner}`)
-    // Finally, send the message with the invite link
+    // Finally, send the embed with all the content
     return msg.channel.send(embed);
   },
 };

--- a/bot/commands/settings.js
+++ b/bot/commands/settings.js
@@ -46,7 +46,7 @@ Sets the server's game name`,
 					if(args.length < 2){
 						return msg.channel.send(utils.errorEmbed('You must supply a prefix to change to'))
 					}
-					guildSettings.prefix = args[1]
+					guildSettings.prefix = args.slice(1).join(" ")
 					return guildSettings.save((err, doc) => {
 						if(err){
 							console.log(err)

--- a/bot/main.js
+++ b/bot/main.js
@@ -77,7 +77,10 @@ client.on('message',async msg => {
     args = msg.content.slice(settings.prefix.length).split(/ +/);
   }
 
-	const commandName = args.shift().toLowerCase();
+  var commandName = args.shift().toLowerCase();
+  if(!commandName) {
+    commandName = args.shift().toLowerCase();
+  }
 
   const command = client.commands.get(commandName)
     || client.commands.find(cmd => cmd.aliases && cmd.aliases.includes(commandName));


### PR DESCRIPTION
- Add help info for `avatar` and `proxy` commands  
- Cinnamon now says `Cleared avatar!` when you issue the `avatar` command without parameters
- Fix permanent invite link in `info` embed (link was renewed)  
- Fix a few typos