### PR TITLE
 Add quote detection to NPC names

### DIFF
--- a/bot/commands/character.js
+++ b/bot/commands/character.js
@@ -22,7 +22,7 @@ module.exports = {
           `<character> reference remove <name>**\nRemoves a reference link from the character `, 
           `<character> rename <New name>**\nRenames the character`,
           `<character> avatar <url | attatchment>**\nSets the characters avatar`,
-          `<character> brithday <birthday>**\nSets the characters birthday`,
+          `<character> birthday <birthday>**\nSets the characters birthday`,
           `<character> nickname <nickname>**\nSets the characters nickname`,
           `<character> proxy <prefix>text<suffix>**\nSets the characters proxy`,
           `<character> pronouns <pronouns>**\nSets the characters pronouns`],

--- a/bot/commands/npc.js
+++ b/bot/commands/npc.js
@@ -6,36 +6,40 @@ const schemas = require('../schemas.js')
 const messages = mongoose.model('messages', schemas.message)
 
 module.exports = {
-	name: 'npc',
-	aliases: ['n'],
-	description: 'Summon an extra',
+  name: 'npc',
+  aliases: ['n'],
+  description: 'Summon an extra',
   perms: [''],
-	hidden: false,
-	args: false,
-	argsMin: 1,
-	usage: ['<name> <text>**\nProxies an npc'],
-	async execute(client, guildSettings, msg, args) {
-		var attachments = utils.attachmentsToFileOptions(msg.attachments)
+  hidden: false,
+  args: false,
+  argsMin: 1,
+  usage: ['<name> <text>**\nProxies an npc'],
+  async execute(client, guildSettings, msg, args) {
+    var attachments = utils.attachmentsToFileOptions(msg.attachments)
 
-		var argLength = 2
-		if(attachments) argLength = 1
+    var argLength = 2
+    if (attachments) argLength = 1
 
-		if(args.length < argLength) return msg.channel.send(utils.errorEmbed("Message cannot be empty"))
+    args = await utils.quoteFinder(args)
+    un = args.slice(0, 1)
+    content = args.slice(1).join(" ")
 
-		hook = await utils.getWebhook(client, msg.channel)
-		un = args.shift()
+    if (un.length + content.length < argLength) return msg.channel.send(utils.errorEmbed("Message cannot be empty"))
 
-		newMessage = await hook.send(args.join(" "), {
-			username: un,
-			avatarURL: "https://cdn.discordapp.com/avatars/582243614030299136/fe639cfe01e197860599ff347eed9998.png?size=256",
-			disableEveryone: true,
-			files: attachments
-		})
-		messageRecord = new messages({
-			_id: newMessage.id,
-			owner: msg.member.id,
-			character: undefined
-		}).save()
-		await msg.delete()
-	},
+    hook = await utils.getWebhook(client, msg.channel)
+
+    newMessage = await hook.send(content, {
+      username: un.join(" "),
+      avatarURL: "https://cdn.discordapp.com/avatars/582243614030299136/fe639cfe01e197860599ff347eed9998.png?size=256",
+      disableEveryone: true,
+      files: attachments
+    })
+
+    messageRecord = new messages({
+      _id: newMessage.id,
+      owner: msg.member.id,
+      character: undefined
+    }).save()
+    await msg.delete()
+  },
 };


### PR DESCRIPTION
- Add quote detection to the NPC command to enable proxying of NPCs with spaces in names.
- Fix a typo in the `character` help output