### PR TITLE
Check reference URL validity

### DIFF
--- a/bot/commands/character.js
+++ b/bot/commands/character.js
@@ -385,6 +385,7 @@ async function setReference(guildSettings, character, msg, args) {
         if(name.length > 30) return msg.channel.send(utils.errorEmbed("Name cannot be longer then 30 characters"))
         var find = character.references.filter(ref => ref.name == name)
         if(find.length != 0) return msg.channel.send(utils.errorEmbed("That reference already exists!"))
+        if (utils.validateUrl(url) !== true) return msg.channel.send(utils.errorEmbed(`\`${url}\` is not a valid URL. Make sure the website exists and that the link starts with \`http://\` or \`https://\`.`))
         character.references.push({
           name: name,
           url: url

--- a/bot/commands/location.js
+++ b/bot/commands/location.js
@@ -219,6 +219,7 @@ async function setReference(guildSettings, location, msg, args) {
         if(name.length > 30) return msg.channel.send(utils.errorEmbed("Name cannot be longer then 30 locations"))
         var find = location.references.filter(ref => ref.name == name)
         if(find.length != 0) return msg.channel.send(utils.errorEmbed("That reference already exists!"))
+        if (utils.validateUrl(url) !== true) return msg.channel.send(utils.errorEmbed(`\`${url}\` is not a valid URL. Make sure the website exists and that the link starts with \`http://\` or \`https://\`.`))
         location.references.push({
           name: name,
           url: url

--- a/bot/util.js
+++ b/bot/util.js
@@ -116,6 +116,11 @@ utils = {
     return /^[0-9A-F]{6}$/i.test(colour.replace("#", ""))
   },
 
+  validateUrl(url) {
+    pattern = new RegExp(/^(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:/?#[\]@!\$&'\(\)\*\+,;=.]+$/igm);
+    return pattern.test(url);
+  },
+
   toTitleCase(str) {
         return str.replace(
             /\w\S*/g,


### PR DESCRIPTION
- Checks the URL structure of references added to both characters and locations using RegExp
  - if the URL structure is malformed, echo the string into an error and inform the user
- This prevents the bot being rejected by the Discord API due to malformed URL segments